### PR TITLE
Add shim option for packages that don't define a style field or use index.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ Valid options:
  * `root`: The directory where all source files are located. This is used for
    source maps. All imported files will have file paths relative to this
    directory in the source maps. By default this uses the `dir` option.
+  * `shim`: If you need to import packages that do not specify a `style` property in their `package.json` or provide their styles in `index.css`, you can provide a shim config option to access them. This is specified as a hash whose keys are the names of packages to shim and whose values are the path, relative to that package's `package.json` file, where styles can be found. e.g. `shim: {'leaflet': 'dist/leaflet.css'}`

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function getImport(scope, opts, rule) {
 
 function processPackage(shimPath) {
     return function (package) {
-        package.main = package.style || shimPath || 'index.css';
+        package.main = shimPath || package.style || 'index.css';
         return package;
     }
 }

--- a/index.js
+++ b/index.js
@@ -48,16 +48,17 @@ function resolveImports(scope, opts, style) {
     style.rules = output;
 }
 
-function resolveImport(dir, rule) {
-    var name = rule.import.replace(QUOTED, '');
+function resolveImport(opts, rule) {
+    var name = rule.import.replace(QUOTED, ''),
+        shimPath = opts.shim ? opts.shim[name] : null;
     if (!isNpmImport(name)) {
         return null;
     }
 
     var options = {
-        basedir: dir,
+        basedir: opts.dir,
         extensions: ['.css'],
-        packageFilter: processPackage
+        packageFilter: processPackage(shimPath)
     };
 
     var file = resolve.sync(name, options);
@@ -65,7 +66,7 @@ function resolveImport(dir, rule) {
 }
 
 function getImport(scope, opts, rule) {
-    var file = resolveImport(opts.dir, rule);
+    var file = resolveImport(opts, rule);
     if (!file) {
         return [rule];
     }
@@ -90,9 +91,11 @@ function getImport(scope, opts, rule) {
     return styles.rules;
 }
 
-function processPackage(package) {
-    package.main = package.style || 'index.css';
-    return package;
+function processPackage(shimPath) {
+    return function (package) {
+        package.main = package.style || shimPath || 'index.css';
+        return package;
+    }
 }
 
 function hasOwn(obj, prop) {

--- a/test.js
+++ b/test.js
@@ -131,3 +131,15 @@ test('Use file names relative to root', function(t) {
         normalize('test/node_modules/test/index.css'));
     t.end();
 });
+
+test('Use shim config option', function(t) {
+    var source = '@import "shimmed";',
+        cfg = {
+            root: __dirname,
+            dir: 'test',
+            shim: {'shimmed': 'some/path/shimmed.css'}
+        },
+        output = rework(source).use(reworkNPM(cfg)).toString();
+    t.equal(output, '.shimmed {\n  content: "Shimmed package";\n}');
+    t.end();
+});

--- a/test/node_modules/shimmed/package.json
+++ b/test/node_modules/shimmed/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "shimmed",
+    "private": true,
+    "version": "0.0.0"
+}

--- a/test/node_modules/shimmed/some/path/shimmed.css
+++ b/test/node_modules/shimmed/some/path/shimmed.css
@@ -1,0 +1,3 @@
+.shimmed {
+    content: "Shimmed package";
+}


### PR DESCRIPTION
This adds the ability to provide a `shim` config option for packages that neither specify a `style` field in their package.json nor provide their styles as `index.css`. The shim option is expected to be a hash, where the key is the package name and the value is the path to the CSS file. The only caveat is that the shimmed package must have a `package.json` file, but that seems like a safe assumption.

I added a test to verify the behavior, and if you're good with the change I can also update the README prior to merging.
