### PR TITLE
Add alias option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ Valid options:
    source maps. All imported files will have file paths relative to this
    directory in the source maps. By default this uses the `dir` option.
   * `shim`: If you need to import packages that do not specify a `style` property in their `package.json` or provide their styles in `index.css`, you can provide a shim config option to access them. This is specified as a hash whose keys are the names of packages to shim and whose values are the path, relative to that package's `package.json` file, where styles can be found. e.g. `shim: {'leaflet': 'dist/leaflet.css'}`
+  * `alias`: You can provide aliases for arbitrary file paths using the same format as the `shim` option. `alias: {'tree': './deep/tree/index.css'}`

--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ Valid options:
  * `root`: The directory where all source files are located. This is used for
    source maps. All imported files will have file paths relative to this
    directory in the source maps. By default this uses the `dir` option.
+  * `shim`: If you need to import packages that do not specify a `style` property in their `package.json` or provide their styles in `index.css`, you can provide a shim config option to access them. This is specified as a hash whose keys are the names of packages to shim and whose values are the path, relative to that package's `package.json` file, where styles can be found. e.g. `shim: {'leaflet': 'dist/leaflet.css'}`

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function getImport(scope, opts, rule) {
 
 function processPackage(shimPath) {
     return function (package) {
-        package.main = package.style || shimPath || 'index.css';
+        package.main = shimPath || package.style || 'index.css';
         return package;
     }
 }

--- a/index.js
+++ b/index.js
@@ -50,9 +50,14 @@ function resolveImports(scope, opts, style) {
 
 function resolveImport(opts, rule) {
     var name = rule.import.replace(QUOTED, ''),
-        shimPath = opts.shim ? opts.shim[name] : null;
+        shimPath = opts.shim ? opts.shim[name] : null,
+        alias = opts.alias ? opts.alias[name] : null;
     if (!isNpmImport(name)) {
         return null;
+    }
+
+    if (alias) {
+        return path.join(opts.dir, alias);
     }
 
     var options = {

--- a/index.js
+++ b/index.js
@@ -48,16 +48,17 @@ function resolveImports(scope, opts, style) {
     style.rules = output;
 }
 
-function resolveImport(dir, rule) {
-    var name = rule.import.replace(QUOTED, '');
+function resolveImport(opts, rule) {
+    var name = rule.import.replace(QUOTED, ''),
+        shimPath = opts.shim ? opts.shim[name] : null;
     if (!isNpmImport(name)) {
         return null;
     }
 
     var options = {
-        basedir: dir,
+        basedir: opts.dir,
         extensions: ['.css'],
-        packageFilter: processPackage
+        packageFilter: processPackage(shimPath)
     };
 
     var file = resolve.sync(name, options);
@@ -65,7 +66,7 @@ function resolveImport(dir, rule) {
 }
 
 function getImport(scope, opts, rule) {
-    var file = resolveImport(opts.dir, rule);
+    var file = resolveImport(opts, rule);
     if (!file) {
         return [rule];
     }
@@ -90,9 +91,11 @@ function getImport(scope, opts, rule) {
     return styles.rules;
 }
 
-function processPackage(package) {
-    package.main = package.style || 'index.css';
-    return package;
+function processPackage(shimPath) {
+    return function (package) {
+        package.main = package.style || shimPath || 'index.css';
+        return package;
+    }
 }
 
 function hasOwn(obj, prop) {

--- a/test.js
+++ b/test.js
@@ -143,3 +143,15 @@ test('Use shim config option', function(t) {
     t.equal(output, '.shimmed {\n  content: "Shimmed package";\n}');
     t.end();
 });
+
+test('Use alias config option', function(t) {
+    var source = '@import "tree";',
+        cfg = {
+            root: __dirname,
+            dir: 'test',
+            alias: {'tree': './deep/tree/index.css'}
+        },
+        output = rework(source).use(reworkNPM(cfg)).toString();
+    t.equal(output, '.test {\n  content: "Test file";\n}');
+    t.end();
+});

--- a/test.js
+++ b/test.js
@@ -131,3 +131,15 @@ test('Use file names relative to root', function(t) {
         normalize('test/node_modules/test/index.css'));
     t.end();
 });
+
+test('Use shim config option', function(t) {
+    var source = '@import "shimmed";',
+        cfg = {
+            root: __dirname,
+            dir: 'test',
+            shim: {'shimmed': 'some/path/shimmed.css'}
+        },
+        output = rework(source).use(reworkNPM(cfg)).toString();
+    t.equal(output, '.shimmed {\n  content: "Shimmed package";\n}');
+    t.end();
+});

--- a/test/deep/tree/index.css
+++ b/test/deep/tree/index.css
@@ -1,0 +1,3 @@
+.test {
+    content: "Test file";
+}

--- a/test/node_modules/shimmed/package.json
+++ b/test/node_modules/shimmed/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "shimmed",
+    "private": true,
+    "version": "0.0.0"
+}

--- a/test/node_modules/shimmed/some/path/shimmed.css
+++ b/test/node_modules/shimmed/some/path/shimmed.css
@@ -1,0 +1,3 @@
+.shimmed {
+    content: "Shimmed package";
+}


### PR DESCRIPTION
Adds the ability to create/use aliases for arbitrary file paths, as discussed in #2.
#2 should be merged first, as this commit was made in the context of those changes.

/cc @Techwraith
