### PR TITLE
Pass filename as second arg to prefilter

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ function getImport(scope, opts, rule) {
         importOpts = { dir: importDir, root: opts.root },
         contents = fs.readFileSync(file, 'utf8');
     if (opts.prefilter) {
-        contents = opts.prefilter(contents);
+        contents = opts.prefilter(contents, file);
     }
 
     var styles = parse(contents, {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "devDependencies": {
     "rework": "~0.20.1",
-    "tap": "~0.4.4"
+    "tap": "~0.4.4",
+    "node-sass": "^0.8.1"
   },
   "dependencies": {
     "resolve": "~0.6.1",

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ var test = require('tap').test,
     fs = require('fs'),
     rework = require('rework'),
     reworkNPM = require('./'),
+    sass = require('node-sass'),
     normalize = require('path').normalize;
 
 test('Import relative source file', function(t) {
@@ -171,6 +172,22 @@ test('Allow prefiltering input CSS (e.g. css-whitespace)', function(t) {
     t.end();
 
     function replacer(code) {
+        return code.replace('$replaceThis', 'content');
+    }
+});
+
+test('Provide filename as second arg to prefilter', function(t) {
+    var source = '@import "./styles/index-unfiltered.css";\n@import "sassy";',
+        output = rework(source)
+            .use(reworkNPM({ root: __dirname, dir: 'test', prefilter: replacer }))
+            .toString();
+
+    t.equal(output, '.test {\n  content: "Test file";\n}\n\n.bashful {\n  color: red;\n}');
+    t.end();
+
+    function replacer(code, filename) {
+        if (filename.indexOf('.scss') > 0) return sass.renderSync({data: code})
+
         return code.replace('$replaceThis', 'content');
     }
 });

--- a/test/node_modules/sassy/package.json
+++ b/test/node_modules/sassy/package.json
@@ -1,0 +1,3 @@
+{
+  "style": "styles.scss"
+}

--- a/test/node_modules/sassy/styles.scss
+++ b/test/node_modules/sassy/styles.scss
@@ -1,0 +1,5 @@
+$rojo: red;
+
+.bashful {
+    color: $rojo;
+}


### PR DESCRIPTION
As the test shows, this allows forking the prefilter behavior based on file type. This would be very useful for us in atomify-css. :)
