### PR TITLE
Ensure prefilter is preserved when drilling down to next level

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,8 +83,11 @@ function getImport(scope, opts, rule) {
 
     scope[file] = true;
 
-    var importDir = path.dirname(file),
-        importOpts = { dir: importDir, root: opts.root },
+    var importOpts = {
+            dir: path.dirname(file),
+            root: opts.root,
+            prefilter: opts.prefilter
+        },
         contents = fs.readFileSync(file, 'utf8');
     if (opts.prefilter) {
         contents = opts.prefilter(contents, file);


### PR DESCRIPTION
Without this, only files `@import`ed directly from the entry file are passed to prefilter. 
