### PR TITLE
Fix example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ output.
 var rework = require('rework'),
     reworkNPM = require('rework-npm');
 
-var output = rework('@import "test"')
+var output = rework('@import "test";')
     .use(reworkNPM())
     .toString();
 


### PR DESCRIPTION
Fixes "Error: missing '{' near line 1:15" thrown from missing semicolon.
