### PR TITLE
Support "main" for compatibility with Bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Import CSS styles from NPM modules using
 [rework](https://github.com/reworkcss/rework).
 
 This lets you use `@import` CSS using the same rules you use for `require` in
-Node. Specify the CSS file for a module using the `style` field in
+Node. Specify the CSS file for a module using the `style` or `main` field in
 `package.json` and use `@import "my-module";`, or specify the file name in the
 module, like `@import "my-module/my-file";`. You can also require files relative
 to the current file using `@import "./my-file";`.

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function reworkNPM(opts) {
     function processPackage(pkg) {
         pkg.main =
             (hasOwn(shim, pkg.name) && shim[pkg.name]) ||
-            pkg.style || 'index.css';
+            pkg.style || pkg.main || 'index.css';
         return pkg;
     }
 


### PR DESCRIPTION
Packages such as purecss work with Bower by setting the "main" field in package.json to the CSS file. This change makes such packages work with rework-npm out of the box.
